### PR TITLE
Add mergiraf

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Feel free to contribute.
 * [git when-merged](https://github.com/mhagger/git-when-merged) - Determine when a particular commit was merged into a git branch.
 * [git-fiddle](https://github.com/felixSchl/git-fiddle) - Edit commit messages, authors, and timestamps during git-rebase.
 * [git-imerge](https://github.com/mhagger/git-imerge) - Incremental merge and rebase for Git.
+* [mergiraf](https://codeberg.org/mergiraf/mergiraf) - A syntax-aware git merge driver (based on tree-sitter like difftasic but for merge conflicts)
 
 ## Hooks
 * [Git Hound](https://github.com/ezekg/git-hound) - Git plugin that prevents sensitive data from being committed.


### PR DESCRIPTION
I’ve added mergiraf to the list of merge tool. Like difftastic it’s based on tree-sitter, but it handles merge conflicts instead of diffs. If you want you can look at the [official documentation](https://mergiraf.org/). I don’t think it matters, but it’s hosted on codeberg, not github unlike the other links.